### PR TITLE
Add strudelFft to hydras function scope.

### DIFF
--- a/packages/web/src/lib/hydra-wrapper.ts
+++ b/packages/web/src/lib/hydra-wrapper.ts
@@ -7,7 +7,7 @@ declare global {
     src: Function;
     H: Function;
     P5: Function;
-    strudelFft: (index: number, buckets: number) => number;
+    fft: (index: number, buckets: number) => number;
   }
 }
 
@@ -69,9 +69,9 @@ export class HydraWrapper {
 
 
     // Enables Hydra to use Strudel frequency data
-    // with `.scrollX(() => strudelFft(1,0)` it will influence the x-axis, according to the fft data
+    // with `.scrollX(() => fft(1,0)` it will influence the x-axis, according to the fft data
     // first number is the index of the bucket, second is the number of buckets to aggregate the number too
-    window.strudelFft = (index: number, buckets: number = 8) => {
+    window.fft = (index: number, buckets: number = 8) => {
       const freq = window.strudel.webaudio.getAnalyzerData("frequency") as Array<number>
       const bucketSize = (freq.length) / buckets
 

--- a/packages/web/src/lib/hydra-wrapper.ts
+++ b/packages/web/src/lib/hydra-wrapper.ts
@@ -71,14 +71,14 @@ export class HydraWrapper {
     // Enables Hydra to use Strudel frequency data
     // with `.scrollX(() => fft(1,0)` it will influence the x-axis, according to the fft data
     // first number is the index of the bucket, second is the number of buckets to aggregate the number too
-    window.fft = (index: number, buckets: number = 8) => {
+    window.fft = (index: number, buckets: number = 8, options?: { min?: number; max?: number, scale?: number }) => {
       const freq = window.strudel.webaudio.getAnalyzerData("frequency") as Array<number>
       const bucketSize = (freq.length) / buckets
 
       // inspired from https://github.com/tidalcycles/strudel/blob/a7728e3d81fb7a0a2dff9f2f4bd9e313ddf138cd/packages/webaudio/scope.mjs#L53
-      const min = -150
-      const scale = .25
-      const max = 0
+      const min = options?.min ?? -150;
+      const scale = options?.scale ?? 1
+      const max = options?.max ?? 0
       const normalized = freq.map((it: number) => {
         const norm = clamp((it - min) / (max - min), 0, 1);
         return norm * scale;

--- a/packages/web/src/lib/strudel-wrapper.ts
+++ b/packages/web/src/lib/strudel-wrapper.ts
@@ -33,6 +33,7 @@ export class StrudelWrapper {
   protected _docPatterns: any;
   protected _audioInitialized: boolean;
   protected framer?: any;
+  protected webaudio?: any;
 
   constructor({
     onError,
@@ -49,6 +50,9 @@ export class StrudelWrapper {
 
   async importModules() {
     // import desired modules and add them to the eval scope
+
+    this.webaudio = await import("@strudel/webaudio");
+
     await evalScope(
       import("@strudel/core"),
       import("@strudel/midi"),
@@ -57,7 +61,7 @@ export class StrudelWrapper {
       import("@strudel/osc"),
       import("@strudel/serial"),
       import("@strudel/soundfonts"),
-      import("@strudel/webaudio"),
+      this.webaudio,
       controls
     );
     try {

--- a/packages/web/src/routes/frames/hydra.tsx
+++ b/packages/web/src/routes/frames/hydra.tsx
@@ -56,6 +56,7 @@ export function Component() {
   useAnimationFrame(
     useCallback(() => {
       window.m = window.parent?.mercury?.m;
+      window.strudel = window.parent?.strudel?.strudel;
     }, [])
   );
 

--- a/packages/web/src/routes/frames/strudel.tsx
+++ b/packages/web/src/routes/frames/strudel.tsx
@@ -34,6 +34,8 @@ export function Component() {
       }
     };
 
+    window.strudel = instance;
+
     window.addEventListener("message", handleWindowMessage);
 
     return () => {


### PR DESCRIPTION
It will hook into strudels analyze engine and expose that data to the hydra scope.
Caveats from this is, that only patterns with a '.scope()' (or similar) call will be included into the resulting fft data.

I dont like the name, but I dont have a better one yet.

Example Usage:

```ts

 solid(() => strudelFft(0,1), 0)
  .mask(shape(5,.05))
  .rotate(({time}) => 50 *  strudelFft(0, 40))

```